### PR TITLE
UPDATE ] 2.0.0

### DIFF
--- a/WPModuleNetwork/Classes/WPError/WPHttpStatusError.swift
+++ b/WPModuleNetwork/Classes/WPError/WPHttpStatusError.swift
@@ -12,7 +12,7 @@ public struct WPHttpStatusError {
     public let code: Int
     public let status: WPHttpStatus
     
-    init(_ code: Int, _ status: WPHttpStatus) {
+    public init(_ code: Int, _ status: WPHttpStatus) {
         self.code = code
         self.status = status
     }
@@ -55,7 +55,7 @@ public enum WPHttpStatus {
         }
     }
 
-    static func get(from code: Int) -> WPHttpStatus {
+    public static func get(from code: Int) -> WPHttpStatus {
         switch code {
         case 100..<200:
             return .conditionalResponse

--- a/WPModuleNetwork/Classes/WPNetworkError.swift
+++ b/WPModuleNetwork/Classes/WPNetworkError.swift
@@ -27,7 +27,7 @@ public enum WPNetworkError: Error {
         case .responseHandling(let error):
             return error.errorMessage
         case .server(let code, let message):
-            return "\(code)" + message
+            return "\(code): " + message
         case .other(let message):
             return message
         }


### PR DESCRIPTION
### Change

- WPHttpStatus의 Initializer 및 Instance Method AccessControl 변경되었습니다.
-> (기존)internal -> (변경)public
- ErrorDescription .server 케이스의 에러 메세지가 에러코드와 메세지가 붙어 있어 식별에 어려움이 있어 메세지 형식을 변경하였습니다.
-> ex) 504servererror -> 504: servererror
